### PR TITLE
Prefer stop with guaranteed transfer

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/TransferMapper.java
@@ -3,6 +3,7 @@ package org.opentripplanner.gtfs.mapping;
 import org.opentripplanner.model.Route;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.Transfer;
+import org.opentripplanner.model.TransferPriority;
 import org.opentripplanner.model.TransferType;
 import org.opentripplanner.model.Trip;
 
@@ -60,6 +61,14 @@ class TransferMapper {
 
         Collection<Stop> fromStops = getStopOrChildStops(rhs.getFromStop());
         Collection<Stop> toStops = getStopOrChildStops(rhs.getToStop());
+
+        for (Stop stop : new Stop[]{stopMapper.map(rhs.getFromStop()), stopMapper.map(rhs.getToStop())}) {
+          if (stop != null && stop.getTransferPriority() == TransferPriority.ALLOWED) {
+            if (transferType == TransferType.GUARANTEED) {
+              stop.setTransferPriority(TransferPriority.PREFERRED);
+            }
+          }
+        }
 
         Collection<Transfer> lhs = new ArrayList<>();
 

--- a/src/main/java/org/opentripplanner/model/Stop.java
+++ b/src/main/java/org/opentripplanner/model/Stop.java
@@ -38,6 +38,8 @@ public final class Stop extends StationElement implements StopLocation {
 
   private HashSet<BoardingArea> boardingAreas;
 
+  private TransferPriority costTransferPriority = TransferPriority.ALLOWED;
+
   public Stop(
       FeedScopedId id,
       String name,
@@ -122,13 +124,21 @@ public final class Stop extends StationElement implements StopLocation {
     return boardingAreas != null ? boardingAreas : Collections.emptySet();
   }
 
+  public TransferPriority getTransferPriority() {
+    return costTransferPriority;
+  }
+
+  public void setTransferPriority(TransferPriority newPriority) {
+    costTransferPriority = newPriority;
+  }
+
   /**
    * Get the transfer cost priority for Stop. This will fetch the value from the parent
    * [if parent exist] or return the default value.
    */
   @NotNull
   public TransferPriority getCostPriority() {
-    return isPartOfStation() ? getParentStation().getCostPriority() : TransferPriority.ALLOWED;
+    return isPartOfStation() ? getParentStation().getCostPriority() : costTransferPriority;
   }
 
   public Collection<FareZone> getFareZones() {


### PR DESCRIPTION
Set `TransferPriority.PREFERRED` to any `Stop` that is referred from `guaranteed` transfer. Some kind / some cases workaround for OTP2 missing guaranteed transfer support.

I tested this with
```
      "stopTransferCost": {
          "DISCOURAGED": 72000,
          "ALLOWED":       150,
          "RECOMMENDED":    60,
          "PREFERRED":       0
      },
```
and this fixed our case with Vihanti village stop.

Did you have any other conditions or adjustments in your mind about this case?