### PR TITLE
Add support for new GTFS-Flex v2.1 field names in StopTimes

### DIFF
--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
@@ -66,8 +66,16 @@ class StopTimeMapper {
         lhs.setDropOffType(rhs.getDropOffType());
         lhs.setShapeDistTraveled(rhs.getShapeDistTraveled());
         lhs.setFarePeriodId(rhs.getFarePeriodId());
-        lhs.setFlexWindowStart(rhs.getMinArrivalTime());
-        lhs.setFlexWindowEnd(rhs.getMaxDepartureTime());
+        if (rhs.getStartPickupDropOffWindow() != StopTime.MISSING_VALUE){
+            lhs.setFlexWindowStart(rhs.getStartPickupDropOffWindow());  // New field name
+        } else {
+            lhs.setFlexWindowStart(rhs.getMinArrivalTime());            // Old field name
+        }
+        if (rhs.getEndPickupDropOffWindow() != StopTime.MISSING_VALUE){
+            lhs.setFlexWindowEnd(rhs.getEndPickupDropOffWindow());      // New field name
+        } else {
+            lhs.setFlexWindowEnd(rhs.getMaxDepartureTime());            // Old field name
+        }
         lhs.setFlexContinuousPickup(rhs.getContinuousPickup());
         lhs.setFlexContinuousDropOff(rhs.getContinuousDropOff());
 

--- a/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/StopTimeMapper.java
@@ -66,16 +66,8 @@ class StopTimeMapper {
         lhs.setDropOffType(rhs.getDropOffType());
         lhs.setShapeDistTraveled(rhs.getShapeDistTraveled());
         lhs.setFarePeriodId(rhs.getFarePeriodId());
-        if (rhs.getStartPickupDropOffWindow() != StopTime.MISSING_VALUE){
-            lhs.setFlexWindowStart(rhs.getStartPickupDropOffWindow());  // New field name
-        } else {
-            lhs.setFlexWindowStart(rhs.getMinArrivalTime());            // Old field name
-        }
-        if (rhs.getEndPickupDropOffWindow() != StopTime.MISSING_VALUE){
-            lhs.setFlexWindowEnd(rhs.getEndPickupDropOffWindow());      // New field name
-        } else {
-            lhs.setFlexWindowEnd(rhs.getMaxDepartureTime());            // Old field name
-        }
+        lhs.setFlexWindowStart(rhs.getStartPickupDropOffWindow());
+        lhs.setFlexWindowEnd(rhs.getEndPickupDropOffWindow());
         lhs.setFlexContinuousPickup(rhs.getContinuousPickup());
         lhs.setFlexContinuousDropOff(rhs.getContinuousDropOff());
 


### PR DESCRIPTION
This is an update to OTP server to be able to utilize new StopTime field names introduced in [GTFS-Flex v2.1](https://docs.google.com/document/d/1PyYK6JVzz52XEx3FXqAJmoVefHFqZTHS4Mpn20dTuKE/edit?ts=5fc85991#heading=h.9i1fb17t3lbp) after OTP2 has been released.

**Note:** This PR requires https://github.com/kyyticom/onebusaway-gtfs-modules/pull/2 to be merged and available for this code. 

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)