### PR TITLE
Fetch feedId from route when tripPattern is missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -703,7 +703,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.3.88-SNAPSHOT</version>
+            <version>1.3.95-SNAPSHOT</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/LocationGroupMapper.java
@@ -40,7 +40,7 @@ public class LocationGroupMapper {
     locationGroup = new FlexLocationGroup(mapAgencyAndId(element.getId()));
     locationGroup.setName(element.getName());
 
-    for (org.onebusaway.gtfs.model.Stoplike location : element.getLocations()) {
+    for (org.onebusaway.gtfs.model.StopLocation location : element.getLocations()) {
       if (location instanceof org.onebusaway.gtfs.model.Stop) {
         locationGroup.addLocation(stopMapper.map((org.onebusaway.gtfs.model.Stop) location));
       }

--- a/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
+++ b/src/main/java/org/opentripplanner/updater/stoptime/TripPatternCache.java
@@ -45,7 +45,7 @@ public class TripPatternCache {
         // Create TripPattern if it doesn't exist yet
         if (tripPattern == null) {
             // Generate unique code for trip pattern
-            var id = new FeedScopedId(tripPattern.getFeedId(), generateUniqueTripPatternCode(tripPattern));
+            var id = new FeedScopedId(route.getId().getFeedId(), generateUniqueTripPatternCode(tripPattern));
 
             tripPattern = new TripPattern(id, route, stopPattern);
             


### PR DESCRIPTION
This is an attempt to fix the NPE thrown when MH updater for Riihimäki is configured: 
```
ERROR (GraphUpdaterManager.java:153) Error while running graph writer org.opentripplanner.updater.stoptime.TripUpdateGraphWriterRunnable:
java.lang.NullPointerException: null
	at org.opentripplanner.updater.stoptime.TripPatternCache.getOrCreateTripPattern(TripPatternCache.java:48) ~[otp-shaded.jar:1.1]
	at org.opentripplanner.updater.stoptime.TimetableSnapshotSource.addTripToGraphAndBuffer(TimetableSnapshotSource.java:697) ~[otp-shaded.jar:1.1]
	at org.opentripplanner.updater.stoptime.TimetableSnapshotSource.handleModifiedTrip(TimetableSnapshotSource.java:895) ~[otp-shaded.jar:1.1]
	at org.opentripplanner.updater.stoptime.TimetableSnapshotSource.validateAndHandleModifiedTrip(TimetableSnapshotSource.java:861) ~[otp-shaded.jar:1.1]
	at org.opentripplanner.updater.stoptime.TimetableSnapshotSource.applyTripUpdates(TimetableSnapshotSource.java:237) ~[otp-shaded.jar:1.1]
	at org.opentripplanner.updater.stoptime.TripUpdateGraphWriterRunnable.run(TripUpdateGraphWriterRunnable.java:46) ~[otp-shaded.jar:1.1]
	at org.opentripplanner.updater.GraphUpdaterManager.lambda$execute$0(GraphUpdaterManager.java:151) ~[otp-shaded.jar:1.1]
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[na:na]
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[na:na]
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[na:na]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[na:na]
	at java.base/java.lang.Thread.run(Thread.java:834) ~[na:na]
```

Here is an example of the RT info that MH is sending 
[mh-vehicle-positions.json.txt](https://github.com/kyyticom/OpenTripPlanner/files/6324019/mh-vehicle-positions.json.txt)
and here is the log from OTP server 
[otp-mh-test-2021-04-16.log](https://github.com/kyyticom/OpenTripPlanner/files/6324023/otp-mh-test-2021-04-16.log)

Note that real fix would be to merge https://github.com/opentripplanner/OpenTripPlanner/pull/3284 into our code base, but that would involve updating OBA as well as some models and I am hesitant doing it now.

To be completed by pull request submitter:

- [ ] **issue**: Link to or create an [issue](https://github.com/opentripplanner/OpenTripPlanner/issues) that describes the relevant feature or bug. Add [GitHub keywords](https://help.github.com/articles/closing-issues-using-keywords/) to this PR's description (e.g., `closes #45`).
- [ ] **roadmap**: Check the [roadmap](https://github.com/orgs/opentripplanner/projects/1) for this feature or bug. If it is not already on the roadmap, PLC will discuss as part of the review process.
- [ ] **tests**: Have you added relevant test coverage? Are all the tests passing on [the continuous integration service (Travis CI)](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#continuous-integration)?
- [ ] **formatting**: Have you followed the [suggested code style](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Developers-Guide.md#code-style)? 
- [ ] **documentation**: If you are adding a new configuration option, have you added an explanation to the [configuration documentation](docs/Configuration.md) tables and sections?
- [ ] **changelog**: add a bullet point to the [changelog file](https://github.com/opentripplanner/OpenTripPlanner/blob/master/docs/Changelog.md) with description and link to the linked issue

To be completed by @opentripplanner/plc:

- [ ] reviews and approvals by 2 members, ideally from different organizations
- [ ] **after merging**: update the relevant card on the [roadmap](https://github.com/orgs/opentripplanner/projects/1)